### PR TITLE
GetOrder returns fills in a specific format that needs its own struct

### DIFF
--- a/pkg/bitvavo/order.go
+++ b/pkg/bitvavo/order.go
@@ -199,7 +199,7 @@ type Order struct {
 	Visible bool `json:"visible"`
 
 	// The fills for this order
-	Fills []Fill `json:"fills"`
+	Fills []OrderFill `json:"fills"`
 
 	// How much of this order is filled
 	FilledAmount string `json:"filledAmount"`
@@ -212,6 +212,17 @@ type Order struct {
 
 	// How much fee is paid
 	FeePaid string `json:"feePaid"`
+}
+
+type OrderFill struct {
+	Id          string `json:"id"`
+	Timestamp   int64  `json:"timestamp"`
+	Amount      string `json:"amount"`
+	Price       string `json:"price"`
+	Taker       bool   `json:"taker"`
+	Fee         string `json:"fee"`
+	FeeCurrency string `json:"feeCurrency"`
+	Settled     bool   `json:"settled"`
 }
 
 func (o *Order) UnmarshalJSON(bytes []byte) error {
@@ -257,7 +268,7 @@ func (o *Order) UnmarshalJSON(bytes []byte) error {
 		if err != nil {
 			return err
 		}
-		fills := make([]Fill, len(fillsAny))
+		fills := make([]OrderFill, len(fillsAny))
 		if err := json.Unmarshal(fillsBytes, &fills); err != nil {
 			return err
 		}

--- a/pkg/bitvavo/order.go
+++ b/pkg/bitvavo/order.go
@@ -216,7 +216,7 @@ type Order struct {
 
 type OrderFill struct {
 	Id          string `json:"id"`
-	Timestamp   int64  `json:"timestamp"`
+	Timestamp   uint64 `json:"timestamp"`
 	Amount      string `json:"amount"`
 	Price       string `json:"price"`
 	Taker       bool   `json:"taker"`


### PR DESCRIPTION
I noticed the call to GetOrders crashed on a nil value being dereferenced when decoding Fill structs.
So this crashes when the code dereferences a Side enum that is being decoded and was empty so returns nil.
Looking at the docs at [get-orders](https://docs.bitvavo.com/docs/rest-api/get-orders/), it is clear that the data returned in the fill does not match the struct being used to decode it. So I created a struct that actually matches what is described in the schema, see doc link above.