### PR TITLE
Guard enum parsing against nil across the package

### DIFF
--- a/internal/util/conditional.go
+++ b/internal/util/conditional.go
@@ -12,3 +12,8 @@ func GetOrEmpty[T any](key string, data map[string]any) T {
 	value, exist := data[key]
 	return IfOrElse(exist && value != nil, func() T { return value.(T) }, empty)
 }
+
+func OrZero[T any](value *T) T {
+	var zero T
+	return IfOrElse(value != nil, func() T { return *value }, zero)
+}

--- a/internal/util/conditional_test.go
+++ b/internal/util/conditional_test.go
@@ -1,0 +1,17 @@
+package util
+
+import "testing"
+
+func TestOrZeroNil(t *testing.T) {
+	var p *int
+	if got := OrZero(p); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+func TestOrZeroValue(t *testing.T) {
+	v := 5
+	if got := OrZero(&v); got != 5 {
+		t.Errorf("expected 5, got %d", got)
+	}
+}

--- a/pkg/bitvavo/asset.go
+++ b/pkg/bitvavo/asset.go
@@ -92,10 +92,10 @@ func (m *Asset) UnmarshalJSON(bytes []byte) error {
 	m.Decimals = int64(decimals)
 	m.DepositFee = depositFee
 	m.DepositConfirmations = int64(depositConfirmations)
-	m.DepositStatus = *depositStatuses.Parse(depositStatus)
+	m.DepositStatus = util.OrZero(depositStatuses.Parse(depositStatus))
 	m.WithdrawalFee = withdrawalFee
 	m.WithdrawalMinAmount = withdrawalMinAmount
-	m.WithdrawalStatus = *withdrawalStatuses.Parse(withdrawalStatus)
+	m.WithdrawalStatus = util.OrZero(withdrawalStatuses.Parse(withdrawalStatus))
 	m.Networks = networks
 	m.Message = message
 

--- a/pkg/bitvavo/candle.go
+++ b/pkg/bitvavo/candle.go
@@ -101,7 +101,7 @@ func (c *Candle) UnmarshalJSON(bytes []byte) error {
 	}
 
 	c.Market = market
-	c.Interval = *intervals.Parse(interval)
+	c.Interval = util.OrZero(intervals.Parse(interval))
 	c.Timestamp = int64(candle[0].(float64))
 	c.Open = candle[1].(string)
 	c.High = candle[2].(string)

--- a/pkg/bitvavo/fill.go
+++ b/pkg/bitvavo/fill.go
@@ -68,7 +68,7 @@ func (f *Fill) UnmarshalJSON(bytes []byte) error {
 	f.FillId = fillId
 	f.Timestamp = int64(timestamp)
 	f.Amount = amount
-	f.Side = *sides.Parse(side)
+	f.Side = util.OrZero(sides.Parse(side))
 	f.Price = price
 	f.Taker = taker
 	f.Fee = fee

--- a/pkg/bitvavo/market.go
+++ b/pkg/bitvavo/market.go
@@ -72,11 +72,11 @@ func (m *Market) UnmarshalJSON(bytes []byte) error {
 
 	types := make([]OrderType, len(orderTypesAny))
 	for i := 0; i < len(orderTypesAny); i++ {
-		types[i] = *orderTypes.Parse(orderTypesAny[i].(string))
+		types[i] = util.OrZero(orderTypes.Parse(orderTypesAny[i].(string)))
 	}
 
 	m.Market = market
-	m.Status = *marketStatuses.Parse(status)
+	m.Status = util.OrZero(marketStatuses.Parse(status))
 	m.Base = base
 	m.Quote = quote
 	m.PricePrecision = int64(pricePrecision)

--- a/pkg/bitvavo/nilenum_test.go
+++ b/pkg/bitvavo/nilenum_test.go
@@ -1,0 +1,133 @@
+package bitvavo
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/larscom/bitvavo-go/v2/internal/test"
+)
+
+// Every case here panicked before enum.Parse's nil result was guarded.
+
+func TestOrderUnmarshalMissingSelfTradePrevention(t *testing.T) {
+	body := []byte(`{"orderId":"1","market":"BTC-EUR","status":"filled","side":"buy","orderType":"market","fills":[]}`)
+
+	var o Order
+	if err := json.Unmarshal(body, &o); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, SelfTradePrevention{}, o.SelfTradePrevention)
+}
+
+func TestOrderUnmarshalWithFills(t *testing.T) {
+	body := []byte(`{"orderId":"1","market":"BTC-EUR","status":"filled","side":"buy","orderType":"market","selfTradePrevention":"decrementAndCancel","fills":[{"id":"f1","timestamp":1,"amount":"1","price":"1","taker":true,"fee":"0","feeCurrency":"EUR","settled":true}]}`)
+
+	var o Order
+	if err := json.Unmarshal(body, &o); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, 1, len(o.Fills))
+	test.AssertEqual(t, "f1", o.Fills[0].Id)
+}
+
+func TestCandleUnmarshal12hInterval(t *testing.T) {
+	body := []byte(`{"market":"BTC-EUR","interval":"12h","candle":[[1,"1","1","1","1","1"]]}`)
+
+	var c Candle
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, Interval12h, c.Interval)
+}
+
+func TestCandleUnmarshal1dInterval(t *testing.T) {
+	body := []byte(`{"market":"BTC-EUR","interval":"1d","candle":[[1,"1","1","1","1","1"]]}`)
+
+	var c Candle
+	if err := json.Unmarshal(body, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, Interval1d, c.Interval)
+}
+
+func TestFillUnmarshalMissingSide(t *testing.T) {
+	body := []byte(`{"fillId":"f1","market":"BTC-EUR","orderId":"o1","timestamp":1,"amount":"1","price":"1","taker":true,"fee":"0","feeCurrency":"EUR","settled":true}`)
+
+	var f Fill
+	if err := json.Unmarshal(body, &f); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, Side{}, f.Side)
+}
+
+func TestTradeUnmarshalUnrecognizedSide(t *testing.T) {
+	body := []byte(`{"id":"t1","market":"BTC-EUR","amount":"1","price":"1","side":"unknown","timestamp":1}`)
+
+	var tr Trade
+	if err := json.Unmarshal(body, &tr); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, Side{}, tr.Side)
+}
+
+func TestAssetUnmarshalUnrecognizedStatus(t *testing.T) {
+	body := []byte(`{"symbol":"BTC","name":"Bitcoin","decimals":8,"depositStatus":"UNKNOWN","withdrawalStatus":"UNKNOWN"}`)
+
+	var a Asset
+	if err := json.Unmarshal(body, &a); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, DepositStatus{}, a.DepositStatus)
+	test.AssertEqual(t, WithdrawalStatus{}, a.WithdrawalStatus)
+}
+
+func TestMarketUnmarshalUnrecognizedStatus(t *testing.T) {
+	body := []byte(`{"market":"BTC-EUR","status":"unknown","base":"BTC","quote":"EUR"}`)
+
+	var m Market
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, MarketStatus{}, m.Status)
+}
+
+func TestWithdrawalHistoryUnmarshalUnrecognizedStatus(t *testing.T) {
+	body := []byte(`{"timestamp":1,"symbol":"BTC","amount":"1","address":"a","fee":"0","status":"unknown"}`)
+
+	var w WithdrawalHistory
+	if err := json.Unmarshal(body, &w); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, WithdrawalHistoryStatus{}, w.Status)
+}
+
+func TestSubscribedUnmarshalUnrecognizedChannel(t *testing.T) {
+	body := []byte(`{"subscriptions":{"unknownChannel":["BTC-EUR"]}}`)
+
+	var s Subscribed
+	if err := json.Unmarshal(body, &s); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, 1, len(s.Subscriptions[Channel{}]))
+}
+
+func TestWebSocketEventDataUnmarshalUnrecognizedEvent(t *testing.T) {
+	body := []byte(`{"event":"somethingNew"}`)
+
+	var d WebSocketEventData
+	if err := json.Unmarshal(body, &d); err != nil {
+		t.Fatal(err)
+	}
+
+	test.AssertEqual(t, WebSocketEvent{}, d.Event)
+}

--- a/pkg/bitvavo/order.go
+++ b/pkg/bitvavo/order.go
@@ -279,9 +279,9 @@ func (o *Order) UnmarshalJSON(bytes []byte) error {
 	o.Market = market
 	o.Created = int64(created)
 	o.Updated = int64(updated)
-	o.Status = *orderStatuses.Parse(status)
-	o.Side = *sides.Parse(side)
-	o.OrderType = *orderTypes.Parse(orderType)
+	o.Status = util.OrZero(orderStatuses.Parse(status))
+	o.Side = util.OrZero(sides.Parse(side))
+	o.OrderType = util.OrZero(orderTypes.Parse(orderType))
 	o.Amount = amount
 	o.AmountRemaining = amountRemaining
 	o.Price = price
@@ -290,16 +290,16 @@ func (o *Order) UnmarshalJSON(bytes []byte) error {
 	o.TriggerPrice = triggerPrice
 	o.TriggerAmount = triggerAmount
 	if len(triggerType) > 0 {
-		o.TriggerType = *orderTriggerTypes.Parse(triggerType)
+		o.TriggerType = util.OrZero(orderTriggerTypes.Parse(triggerType))
 	}
 	if len(triggerReference) > 0 {
-		o.TriggerReference = *orderTriggerRefs.Parse(triggerReference)
+		o.TriggerReference = util.OrZero(orderTriggerRefs.Parse(triggerReference))
 	}
 	if len(timeInForce) > 0 {
-		o.TimeInForce = *timeInForces.Parse(timeInForce)
+		o.TimeInForce = util.OrZero(timeInForces.Parse(timeInForce))
 	}
 	o.PostOnly = postOnly
-	o.SelfTradePrevention = *selfTradePreventions.Parse(selfTradePrevention)
+	o.SelfTradePrevention = util.OrZero(selfTradePreventions.Parse(selfTradePrevention))
 	o.Visible = visible
 	o.FilledAmount = filledAmount
 	o.FilledAmountQuote = filledAmountQuote

--- a/pkg/bitvavo/subscribed.go
+++ b/pkg/bitvavo/subscribed.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-json"
+	"github.com/larscom/bitvavo-go/v2/internal/util"
 )
 
 var ErrUnexpectedType = func(v any) error { return fmt.Errorf("unexpected type '%s'", v) }
@@ -32,7 +33,7 @@ func (s *Subscribed) UnmarshalJSON(bytes []byte) error {
 	)
 
 	for key, value := range all {
-		channel := *channels.Parse(key)
+		channel := util.OrZero(channels.Parse(key))
 
 		switch v := value.(type) {
 		// without interval
@@ -45,7 +46,7 @@ func (s *Subscribed) UnmarshalJSON(bytes []byte) error {
 		case map[string]any:
 			subscriptionsInterval[channel] = make(map[Interval][]string)
 			for i, m := range v {
-				interval := *intervals.Parse(i)
+				interval := util.OrZero(intervals.Parse(i))
 				markets := m.([]any)
 				subscriptionsInterval[channel][interval] = make([]string, len(markets))
 				for index, market := range markets {

--- a/pkg/bitvavo/subscription.go
+++ b/pkg/bitvavo/subscription.go
@@ -30,6 +30,8 @@ var (
 	Interval4h  = interval.Add(Interval{"4h"})
 	Interval6h  = interval.Add(Interval{"6h"})
 	Interval8h  = interval.Add(Interval{"8h"})
+	Interval12h = interval.Add(Interval{"12h"})
+	Interval1d  = interval.Add(Interval{"1d"})
 	intervals   = interval.Enum()
 )
 

--- a/pkg/bitvavo/trade.go
+++ b/pkg/bitvavo/trade.go
@@ -89,7 +89,7 @@ func (t *Trade) UnmarshalJSON(bytes []byte) error {
 	t.Market = market
 	t.Amount = amount
 	t.Price = price
-	t.Side = *sides.Parse(side)
+	t.Side = util.OrZero(sides.Parse(side))
 	t.Timestamp = int64(timestamp)
 
 	return nil

--- a/pkg/bitvavo/websocket.go
+++ b/pkg/bitvavo/websocket.go
@@ -76,7 +76,7 @@ func (d *WebSocketEventData) UnmarshalJSON(b []byte) error {
 		return ErrNotEventType
 	}
 
-	d.Event = *webSocketEvents.Parse(event)
+	d.Event = util.OrZero(webSocketEvents.Parse(event))
 	d.Reader = bytes.NewReader(b)
 
 	return nil

--- a/pkg/bitvavo/withdrawal.go
+++ b/pkg/bitvavo/withdrawal.go
@@ -111,7 +111,7 @@ func (w *WithdrawalHistory) UnmarshalJSON(bytes []byte) error {
 	w.PaymentId = paymentId
 	w.TxId = txId
 	w.Fee = fee
-	w.Status = *withDrawalHistoryStatuses.Parse(status)
+	w.Status = util.OrZero(withDrawalHistoryStatuses.Parse(status))
 
 	return nil
 }


### PR DESCRIPTION
I hit a panic similar to #8 in a few other places. bitvavo-go dereferences `enum.Parse`'s result without a nil check in about a dozen spots outside the fills path: order status/side/orderType/selfTradePrevention, standalone `Fill.Side` (used by `FillListener`), `Trade.Side`, `Candle.Interval`, `Market.Status` and its `OrderTypes`, `Asset` deposit/withdrawal status, `WithdrawalHistory.Status`, the `Subscribed` channel/interval keys, and `WebSocketEventData.Event`. Any of these panics on a value the exchange sends that the enum doesn't have, or when the field is legitimately absent - `selfTradePrevention` isn't always present on an order, the same class of bug as the fills side field in #8.

Added a small `util.OrZero(*T) T` helper and used it everywhere `enum.Parse` gets dereferenced, so an unrecognized or missing value degrades to the zero value instead of crashing the whole decode.

While in there I noticed the `Interval` enum stops at 8h, but Bitvavo's candle websocket channel also supports 12h and 1d (docs.bitvavo.com/docs/websocket-api/), so a 12h or 1d candle subscription panicked outright instead of just losing the interval label. Added the two missing members.

Tests cover each case that used to panic.